### PR TITLE
Feature/edd 1588 add translation to emails 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,33 @@ Sometimes you want to update frontend code without upgrade everything else, so i
 ```
 docker-compose -p gtfs-editor -f docker\docker-compose.yml build --no-cache nginx
 ```
+---
+## Install install GNU gettext toolset
+You should only install it if you need to generate .po or .mo files
+
+### Windows
+
+1- Go to this link : https://mlocati.github.io/articles/gettext-iconv-windows.html
+
+2- Download 32 or 64 bit shared and static windows installation files.
+
+3- Install both of files.
+
+4- Restart your computer.
+
+## Linux & Unix-like
+
+Run the following command on terminal:
+
+```
+apt-get update
+apt-get install gettext
+```
+
+## macOS
+
+Installing gettext package on macOS via brew:
+
+```
+brew install gettext
+```

--- a/gtfseditor/settings.py
+++ b/gtfseditor/settings.py
@@ -15,6 +15,7 @@ import sys
 from typing import List
 
 from decouple import config, Csv
+from django.utils.translation import gettext_lazy as _
 
 TESTING = 'test' in sys.argv
 
@@ -57,6 +58,7 @@ LOCAL_APPS = [
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -126,6 +128,11 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
+LANGUAGES = [
+    ('en', _('English')),
+    ('es', _('Spanish')),
+]
+
 TIME_ZONE = 'UTC'
 
 USE_I18N = True
@@ -133,6 +140,10 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale'),
+]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/

--- a/user/jobs.py
+++ b/user/jobs.py
@@ -1,6 +1,7 @@
 from django_rq import job
 from django.template.loader import render_to_string
 from django.core.mail import EmailMultiAlternatives
+from django.utils.translation import gettext as _
 
 from gtfseditor import settings
 from user.models import User
@@ -9,7 +10,7 @@ from user.models import User
 @job('default', timeout=300)
 def send_confirmation_email(username, verification_url):
     user = User.objects.get(username=username)
-    subject, to = 'Verificación de Email', user.email
+    subject, to = _("Email Verification"), user.email
     text_content = ''
     html_content = render_to_string('confirmation_email.html',
                                     context={'username': user.username,
@@ -22,7 +23,7 @@ def send_confirmation_email(username, verification_url):
 @job('default', timeout=300)
 def send_pw_recovery_email(username, recovery_url):
     user = User.objects.get(username=username)
-    subject, to = 'Recuperación de contraseña', user.email
+    subject, to = _("Password Recovery"), user.email
     text_content = ''
     html_content = render_to_string('recover_password.html',
                                     context={'username': user.username,

--- a/user/locale/es_ES/LC_MESSAGES/django.po
+++ b/user/locale/es_ES/LC_MESSAGES/django.po
@@ -1,0 +1,89 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 18:48-0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: .\jobs.py:13
+#, fuzzy
+#| msgid "Email Confirmation"
+msgid "Email Verification"
+msgstr "Confirmación de correo electrónico"
+
+#: .\jobs.py:26 .\templates\recover_password.html:6
+msgid "Password Recovery"
+msgstr "Recuperación de Contraseña"
+
+#: .\templates\confirmation_email.html:6
+msgid "Email Confirmation"
+msgstr "Confirmación de correo electrónico"
+
+#: .\templates\confirmation_email.html:101
+#: .\templates\recover_password.html:105
+msgid "Hello"
+msgstr "Hola"
+
+#: .\templates\confirmation_email.html:104
+msgid ""
+"\n"
+"                <p><b>Welcome to the <span>GTFS editor</span> of "
+"<span>TranSapp.</span></b></p>\n"
+"                <p>As a final step, we need to verify your <b>email address</"
+"b> to ensure everything is in order.</p>\n"
+"                <p>Please take a moment to click the button below and "
+"confirm your <b>email address:</b></p>\n"
+"                "
+msgstr ""
+"\n"
+"                <p><b>Bienvenido al <span>editor de GTFS</span> de "
+"<span>TranSapp.</span></b></p>\n"
+"                <p>Como último paso, necesitamos verificar tu <b>dirección "
+"de correo electrónico</b> para asegurarnos de que todo esté en orden.</p>\n"
+"                <p>Por favor, toma un momento para hacer clic en el botón de "
+"abajo y confirmar tu <b>dirección de correo:</b></p>\n"
+"                "
+
+#: .\templates\confirmation_email.html:111
+msgid "CONFIRM"
+msgstr "CONFIRMAR"
+
+#: .\templates\confirmation_email.html:115
+msgid "If you did not create an account with us, please ignore this message."
+msgstr "Si no creó una cuenta con nosotros, por favor ignora este mensaje."
+
+#: .\templates\recover_password.html:108
+msgid ""
+"\n"
+"                <p><b>We have received a request to <span>modify</span> the "
+"<span>password</span> for your <span>GTFS editor</span> account on "
+"<span>TranSapp.</span></b></p>\n"
+"                <p>To proceed, click the button below:</p>\n"
+"                "
+msgstr ""
+"\n"
+"                <p><b>Hemos recibido una solicitud para <span>modificar</"
+"span> la <span>contraseña</span> de tu cuenta del <span>editor de GTFS</"
+"span> de <span>TranSapp.</span></b></p>\n"
+"                <p> Para continuar, haz clic en el siguiente botón:</p>\n"
+"                "
+
+#: .\templates\recover_password.html:114
+msgid "RESET PASSWORD"
+msgstr "RESTABLECER CONTRASEÑA"
+
+#: .\templates\recover_password.html:118
+msgid "If you have not requested a password change, please ignore this email."
+msgstr "Si no ha solicitado un cambio de contraseña, por favor ignore este correo."

--- a/user/templates/confirmation_email.html
+++ b/user/templates/confirmation_email.html
@@ -1,8 +1,9 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Confirmación de correo electrónico</title>
+    <title>{% trans "Email Confirmation" %}</title>
     <style>
         body{
             font-family: 'Verdana', sans-serif;
@@ -93,23 +94,25 @@
 <div>
     <div class="container">
         <div class="logo">
-            <img src="https://transapp-static.s3.us-east-2.amazonaws.com/logo-gtfs-editor.svg">
+            <img src="https://transapp-static.s3.us-east-2.amazonaws.com/logo-gtfs-editor.svg" alt="logo">
         </div>
-        <div class= "message-container">
+        <div class="message-container">
             <div class="greeting">
-                ¡Hola <span>{{ username }}</span>!
+                {% trans "Hello" %}, <span>{{ username }}</span>
             </div>
             <div class="message">
-                <p><b>Bienvenido al <span>editor de GTFS</span> de <span>TranSapp.</span></b></p>
-                <p>Como último paso, necesitamos verificar tu <b>dirección de correo electrónico</b> para asegurarnos de que todo esté en orden.</p>
-                <p>Por favor, toma un momento para hacer clic en el botón de abajo y confirmar tu <b>dirección de correo:</b></p>
+                {% blocktranslate %}
+                <p><b>Welcome to the <span>GTFS editor</span> of <span>TranSapp.</span></b></p>
+                <p>As a final step, we need to verify your <b>email address</b> to ensure everything is in order.</p>
+                <p>Please take a moment to click the button below and confirm your <b>email address:</b></p>
+                {% endblocktranslate %}
             </div>
             <div class="button-container">
-                <a href="{{ link_url }}" class="button">CONFIRMAR</a>
+                <a href="{{ link_url }}" class="button">{% trans "CONFIRM" %}</a>
             </div>
         </div>
         <div class="small-text">
-            Si no creaste una cuenta con nosotros. Por favor, ignora este mensaje.
+            {% trans "If you did not create an account with us, please ignore this message." %}
         </div>
     </div>
 </div>

--- a/user/templates/recover_password.html
+++ b/user/templates/recover_password.html
@@ -1,8 +1,9 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Recuperación de Contraseña </title>
+    <title>{% trans "Password Recovery" %}</title>
     <style>
         body{
             font-family: 'Verdana', sans-serif;
@@ -97,22 +98,24 @@
 <div>
     <div class="container">
         <div class="logo">
-            <img src="https://transapp-static.s3.us-east-2.amazonaws.com/logo-gtfs-editor.svg">
+            <img src="https://transapp-static.s3.us-east-2.amazonaws.com/logo-gtfs-editor.svg" alt="logo">
         </div>
-        <div class= "message-container">
+        <div class="message-container">
             <div class="greeting">
-                <span>Hola {{ username }}</span>,
+                {% trans "Hello" %}, <span>{{ username }}</span>
             </div>
             <div class="message">
-                <p><b>Hemos recibido una solicitud para <span>modificar</span> la <span>contraseña</span> de tu cuenta del <span>editor de GTFS</span> de <span>TranSapp.</span></b></p>
-                <p> Para continuar, haz clic en el siguiente botón:</p>
+                {% blocktranslate %}
+                <p><b>We have received a request to <span>modify</span> the <span>password</span> for your <span>GTFS editor</span> account on <span>TranSapp.</span></b></p>
+                <p>To proceed, click the button below:</p>
+                {% endblocktranslate %}
             </div>
             <div class="button-container">
-                <a href="{{ link_url }}" class="button">RESTABLECER CONTRASEÑA</a>
+                <a href="{{ link_url }}" class="button">{% trans "RESET PASSWORD" %}</a>
             </div>
         </div>
         <div class="small-text">
-            Si no has solicitado un cambio de contraseña. Por favor, ignora este correo.
+            {% trans "If you have not requested a password change, please ignore this email." %}
         </div>
     </div>
 </div>

--- a/user/tests/test_translation.py
+++ b/user/tests/test_translation.py
@@ -1,0 +1,82 @@
+from django.test import TestCase
+from django.core import mail
+from django.urls import reverse
+from rest_framework.test import APIClient
+from user.tests.factories import UserFactory
+
+
+class ConfirmationEmailTest(TestCase):
+
+    def setUp(self):
+        self.url = reverse('user-register')
+        self.url_pw = reverse('recover-password-request')
+        self.user = UserFactory()
+
+    def test_send_confirmation_email_with_accept_language_spanish_header(self):
+        data = {
+            'username': 'test',
+            'email': 'test@email.com',
+            'password': 'testPassword',
+            'name': 'testName',
+            'last_name': 'testLastName'
+        }
+
+        client = APIClient(HTTP_ACCEPT_LANGUAGE='es')
+        response = client.post(self.url, data, format='json')
+
+        # Verify that an email has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+
+        # Verify the content of the email.
+        self.assertIn('Si no creó una cuenta con nosotros, por favor ignora este mensaje.', sent_email.alternatives[0][0])
+
+    def test_send_confirmation_email_with_accept_language_english_header(self):
+        data = {
+            'username': 'test',
+            'email': 'test@email.com',
+            'password': 'testPassword',
+            'name': 'testName',
+            'last_name': 'testLastName'
+        }
+
+        client = APIClient(HTTP_ACCEPT_LANGUAGE='en')
+        response = client.post(self.url, data, format='json')
+
+        # Verify that an email has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+
+        # Verify the content of the email.
+        self.assertIn('If you did not create an account with us, please ignore this message.',
+                      sent_email.alternatives[0][0])
+
+    def test_send_recovery_password_with_accept_language_spanish_header(self):
+        data = {'username': self.user.username}
+
+        client = APIClient(HTTP_ACCEPT_LANGUAGE='es')
+        response = client.put(self.url_pw, data, format='json')
+        self.user.refresh_from_db()
+
+        # Verify that an email has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+
+        # Verify the content of the email.
+        self.assertIn('Para continuar, haz clic en el siguiente botón:',
+                      sent_email.alternatives[0][0])
+
+    def test_send_recovery_password_with_accept_language_english_header(self):
+        data = {'username': self.user.username}
+
+        client = APIClient(HTTP_ACCEPT_LANGUAGE='en')
+        response = client.put(self.url_pw, data, format='json')
+        self.user.refresh_from_db()
+
+        # Verify that an email has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        sent_email = mail.outbox[0]
+
+        # Verify the content of the email.
+        self.assertIn('To proceed, click the button below:',
+                      sent_email.alternatives[0][0])


### PR DESCRIPTION
- Se implementó la funcionalidad de: traducción en los mails de confirmación de correo y de recuperación de contraseña
- Se agregó en readme.md cómo instalar gettext si se necesita crear archivos .po o  .mo
- Se verificó que se efectivamente se cambiara el idioma del mail dependiendo del cliente