### PR TITLE
hotfix(uploadGTFS): removed comment

### DIFF
--- a/rest_api/views.py
+++ b/rest_api/views.py
@@ -339,8 +339,7 @@ class ProjectViewSet(MyModelViewSet):
 
         project_obj.creation_status = Project.CREATION_STATUS_LOADING_GTFS
         project_obj.save()
-        #upload_gtfs_file_when_project_is_created.delay(project_obj.pk, gtfs_content)
-        upload_gtfs_file_when_project_is_created(project_obj.pk, gtfs_content)
+        upload_gtfs_file_when_project_is_created.delay(project_obj.pk, gtfs_content)
         return Response(ProjectSerializer(project_obj).data, status.HTTP_200_OK)
 
     @action(detail=True, methods=['POST'])


### PR DESCRIPTION
<!-- Para una versión en inglés de esta plantilla, añade &template=pull_request_template_en.md a la URL -->

<!-- Título del PR: Utiliza el formato de Conventional Commits -->
<!-- Ejemplo: feat(EDD-0000): descripción breve del cambio -->

# 📚 Context

<!-- Proporciona una descripción general breve del propósito de este PR. Indica claramente qué problema aborda o qué funcionalidad agrega/cambia. Incluye enlaces a tickets de Jira, problemas o documentación relevante, si aplica. -->

The process of uploading a gtfs file has some issues related to the `create_or_update_chunks` method. In the method, rows that have a foreign key that hasn't been created yet (because they are in the same chunk) displays an error trying to find the uncreated record.

Besides, there is a problem with the field end_time of frequencies.txt where its value can exceed 23:59:59, causing django to raise an exception. This value has to be preprocessed before saving it.

# 📝 Changes

<!-- Detalla los cambios específicos realizados en este PR. Puedes organizarlos por capas para mayor claridad. -->

- [x] Changed create_or_update_chunk logic. First, we separate the chunk into `rows_without_fk` and `rows_with_fk`, storing the first list, then processing the second one.
- [x] Modified models Stops and Transfer.
- [x] Added `process_model_rows` and `create_and_update_chunk` methods into services/process.py (create_or_update_chunk's logic)
- [x] Added a preprocess method in FrequenciesViewSet for end_time attribute.
- [x] Added an error message when a stop or trip id is inside stop_times.txt but not in stops.txt or trips.txt.

# 🔍 What to test
<!--¿Qué hay que probar para validar el PR? Más importante si el PR es a Producción y se puede revisar en Desarrollo -->
- [ ] Upload Belize's GTFS file provided in the Jira issue to see the error of stop_times.txt error raising.
- [ ] Upload Belize's GTFS file provides in the Jira issue but fixing the errors and then uploading it succesfully.
- [ ] Upload DTPM's GTFS for seeing it being uploading succesfully.

<!-- ## 📸 Demo

 Incluye capturas de pantalla, GIFs o grabaciones de pantalla que muestren los cambios realizados en este PR. Asegúrate de destacar los aspectos clave de las modificaciones. -->

<!-- # 📌 Pendiente -->
<!-- Puedes incluir elementos adicionales en la lista de verificación que los colaboradores deben completar antes de que este PR pueda considerarse listo. -->

# ✅ **Criterios para aprobación**

Para que este PR sea aprobado, se debe cumplir con los siguientes puntos:

- [ ] **Aprobación del equipo backend**:
  - El PR debe ser aprobado por al menos **dos miembros** del equipo de backend.
  - Dependiendo del caso, es posible que se necesite la aprobación miembros de otros equipos.
- [ ] **Título del PR en formato Conventional Commits**
- [ ] **Cumple la funcionalidad propuesta**: El PR resuelve correctamente el problema o agrega la funcionalidad indicada en el contexto.
- [ ] **Sigue las convenciones de arquitectura del equipo**:
  - El código respeta los principios de Django-Styleguide.
  - Si es un Endpoint utiliza Django-DRF, etc.
- [ ] **Pasa las verificaciones técnicas**:
  - Todos los tests se ejecutan correctamente.
  - No genera errores en el analyzer de lint. _(Coming soon)_
- [ ] **Incluye tests adecuados**: Se han agregado pruebas, al menos para los casos borde de la funcionalidad desarrollada.
- [ ] **Documentación**: Si es una nueva funcionalidad, esta ha sido documentada según los estándares del equipo.
  - Si es un endpoint de Teléfono, éste debe de estar documentado en su respectivo Confluence.
- [ ] **Calidad textual**: No hay errores de redacción ni sintaxis en los textos agregados o modificados en el código.
- [ ] **Verificación de la capa de presentación**:
  - Si se modifica la capa de presentación, el PR a producción debe ser asignado al equipo de diseño para su revisión.
  - En la mayoría de los casos, utilizando el ambiente de Desarrollo para validar el diseño.
- [ ] **Formato del código**:
  - El código debe seguir las convenciones de formato de PEP-8