### PR TITLE
hotfix(jobs.py): add 'feed_info.txt' to uploader file list

### DIFF
--- a/rqworkers/jobs.py
+++ b/rqworkers/jobs.py
@@ -52,7 +52,7 @@ def upload_gtfs_file(project_pk, zip_file):
                     for uploader_filename in [
                         "agency.txt", "calendar.txt", "routes.txt", "shapes.txt", "trips.txt", "frequencies.txt",
                         "calendar_dates.txt", "levels.txt", "stops.txt", "stop_times.txt", "transfers.txt",
-                        "pathways.txt", "fare_attributes.txt", "fare_rules.txt"
+                        "pathways.txt", "fare_attributes.txt", "fare_rules.txt", 'feed_info.txt'
                     ]:
                         uploader = uploaders[uploader_filename]
                         try:


### PR DESCRIPTION
# Contexto
Al subir un GTFS nuevo la información del feed_info no está siendo guardada

## Cambios

- Se agrega el archivo feed_info a la hora de procesar el GTFS